### PR TITLE
Remember last saved info per player

### DIFF
--- a/train.lua
+++ b/train.lua
@@ -1,6 +1,5 @@
 
-local last_index = 0
-local last_line = ""
+local last_set_by = {}
 
 local update_formspec = function(meta)
 	local line = meta:get_string("line")
@@ -40,12 +39,56 @@ minetest.register_node("mapserver:train", {
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
 
-		last_index = last_index + 5
+		local find_nearest_player = function(pos, radius)
+			-- adapted from https://forum.minetest.net/viewtopic.php?t=23319
+
+			local closest_d = radius+1
+			local closest_name
+
+			for i, obj in ipairs(minetest.get_objects_inside_radius(pos, radius)) do
+				-- 0.4.x compatibility:
+				--if obj:get_player_name() ~= "" then
+
+				-- 5.0.0+ method:
+				if minetest.is_player(obj) then
+					local distance = vector.distance(obj:get_pos(), pos)
+					if distance < closest_d then
+						closest_d = distance
+						closest_name = obj:get_player_name()
+					end
+				end
+			end
+
+			-- if 'closest_name' is nil, there's no player inside that radius
+			return closest_name
+		end
+
+		-- 10 should be the max possible interaction distance
+		local name = find_nearest_player(pos, 10)
+
+		local last_index = 0
+		local last_line = ""
+		local last_color = ""
+
+		if name ~= nil then
+			name = string.lower(name)
+			if last_set_by[name] ~= nil then
+				last_index = last_set_by[name].index + 5
+				last_line = last_set_by[name].line
+				last_color = last_set_by[name].color
+			else
+				last_set_by[name] = {}
+			end
+
+			last_set_by[name].index = last_index
+			last_set_by[name].line = last_line
+			last_set_by[name].color = last_color
+		end
 
 		meta:set_string("station", "")
 		meta:set_string("line", last_line)
 		meta:set_int("index", last_index)
-		meta:set_string("color", "")
+		meta:set_string("color", last_color)
 
 		update_formspec(meta)
 	end,
@@ -57,17 +100,27 @@ minetest.register_node("mapserver:train", {
 		end
 
 		local meta = minetest.get_meta(pos)
+		local name = string.lower(sender:get_player_name())
 
 		if fields.save then
-			last_line = fields.line
+			if last_set_by[name] == nil then
+				last_set_by[name] = {}
+			end
+
+			local index = tonumber(fields.index)
+			if index ~= nil then
+				index = index
+			end
+
 			meta:set_string("color", fields.color)
 			meta:set_string("line", fields.line)
 			meta:set_string("station", fields.station)
-			local index = tonumber(fields.index)
-			if index ~= nil then
-				last_index = index
-				meta:set_int("index", index)
-			end
+			meta:set_int("index", index)
+
+			last_set_by[name].color = fields.color
+			last_set_by[name].line = fields.line
+			last_set_by[name].station = fields.station
+			last_set_by[name].index = index
 		end
 
 		update_formspec(meta)

--- a/train.lua
+++ b/train.lua
@@ -39,19 +39,19 @@ minetest.register_node("mapserver:train", {
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
 
-		local find_nearest_player = function(pos, radius)
+		local find_nearest_player = function(block_pos, radius)
 			-- adapted from https://forum.minetest.net/viewtopic.php?t=23319
 
 			local closest_d = radius+1
 			local closest_name
 
-			for i, obj in ipairs(minetest.get_objects_inside_radius(pos, radius)) do
+			for i, obj in ipairs(minetest.get_objects_inside_radius(block_pos, radius)) do
 				-- 0.4.x compatibility:
 				--if obj:get_player_name() ~= "" then
 
 				-- 5.0.0+ method:
 				if minetest.is_player(obj) then
-					local distance = vector.distance(obj:get_pos(), pos)
+					local distance = vector.distance(obj:get_pos(), block_pos)
 					if distance < closest_d then
 						closest_d = distance
 						closest_name = obj:get_player_name()

--- a/train.lua
+++ b/train.lua
@@ -34,55 +34,30 @@ minetest.register_node("mapserver:train", {
 	groups = {cracky=3,oddly_breakable_by_hand=3},
 	sounds = moditems.sound_glass(),
 	can_dig = mapserver.can_interact,
-	after_place_node = mapserver.after_place_node,
 
-	on_construct = function(pos)
+	after_place_node = function(pos, placer, itemstack, pointed_thing)
 		local meta = minetest.get_meta(pos)
-
-		local find_nearest_player = function(block_pos, radius)
-			-- adapted from https://forum.minetest.net/viewtopic.php?t=23319
-
-			local closest_d = radius+1
-			local closest_name
-
-			for i, obj in ipairs(minetest.get_objects_inside_radius(block_pos, radius)) do
-				-- 0.4.x compatibility:
-				--if obj:get_player_name() ~= "" then
-
-				-- 5.0.0+ method:
-				if minetest.is_player(obj) then
-					local distance = vector.distance(obj:get_pos(), block_pos)
-					if distance < closest_d then
-						closest_d = distance
-						closest_name = obj:get_player_name()
-					end
-				end
-			end
-
-			-- if 'closest_name' is nil, there's no player inside that radius
-			return closest_name
-		end
-
-		-- 10 should be the max possible interaction distance
-		local name = find_nearest_player(pos, 10)
 
 		local last_index = 0
 		local last_line = ""
 		local last_color = ""
 
-		if name ~= nil then
-			name = string.lower(name)
-			if last_set_by[name] ~= nil then
-				last_index = last_set_by[name].index + 5
-				last_line = last_set_by[name].line
-				last_color = last_set_by[name].color
-			else
-				last_set_by[name] = {}
-			end
+		if minetest.is_player(placer) then
+			local name = placer:get_player_name()
+			if name ~= nil then
+				name = string.lower(name)
+				if last_set_by[name] ~= nil then
+					last_index = last_set_by[name].index + 5
+					last_line = last_set_by[name].line
+					last_color = last_set_by[name].color
+				else
+					last_set_by[name] = {}
+				end
 
-			last_set_by[name].index = last_index
-			last_set_by[name].line = last_line
-			last_set_by[name].color = last_color
+				last_set_by[name].index = last_index
+				last_set_by[name].line = last_line
+				last_set_by[name].color = last_color
+			end
 		end
 
 		meta:set_string("station", "")
@@ -91,6 +66,9 @@ minetest.register_node("mapserver:train", {
 		meta:set_string("color", last_color)
 
 		update_formspec(meta)
+
+
+		return mapserver.after_place_node(pos, placer, itemstack, pointed_thing)
 	end,
 
 	on_receive_fields = function(pos, formname, fields, sender)


### PR DESCRIPTION
*This is a neater, rebased version of #15.*

Currently, if multiple players are placing trainline blocks at the same time and rely on the mod remembering the line and automatically increasing the index, they mess both of their progress up. This is because we currently only remember the last line and index, globally.

This PR replaces those two variables with a table, where the relevant information is stored per player. ~~We also remember all of the last set information~~ and only use part of it when the player places the next trainline block.

When I wrote the last commit, because the online map regarded only the blocks inside the current viewport at any given time, I decided to also "replay" the last set color value for newly set blocks. Given the [recently merged solution of the original problem](https://github.com/minetest-mapserver/mapserver/pull/230), it might make sense to remove this again to make it easier to change the color of a whole line.