### PR TITLE
Add support for realtime AirUtils-based planes

### DIFF
--- a/bridge/airutils_planes.lua
+++ b/bridge/airutils_planes.lua
@@ -1,0 +1,89 @@
+
+local planes = {}
+
+-- we monkey patch various functions within airutils to let us know when plane entities are
+-- added, updated, or removed from game scope
+-- planes deactivated by the game (no players in range, etc) will not be sent to mapserver
+if airutils then
+    minetest.log("info", "[mapserver-bridge] patching airutils functions to track planes")
+    local au_setText = airutils.setText
+    local au_actfunc = airutils.actfunc
+    local au_save_inv = airutils.save_inventory
+
+    -- actfunc is always called when planes are activated, so it provides
+    -- a single convenient point to start tracking them
+    if au_actfunc and (type(au_setText) == "function") then
+        airutils.actfunc = function(self, staticdata, dtime_s)
+            if not self.__id then
+                self.__id = tostring(math.random())
+            end
+            planes[self.__id] = self
+
+            -- call original
+            return au_actfunc(self, staticdata, dtime_s)
+        end
+    end
+
+    -- save_inventory is called when planes are deactivated, so it provides
+    -- a single convenient point to untrack them
+    if au_save_inv and (type(au_setText) == "function") then
+        airutils.save_inventory = function(self)
+            if planes[self.__id] then
+                planes[self.__id] = nil
+            end
+
+            -- call original
+            return au_save_inv(self)
+        end
+    end
+
+    -- this is a convenience, which allows us to grab the "proper name"
+    -- of the plane
+    if au_setText and (type(au_setText) == "function") then
+        airutils.setText = function(self, vehicle_name)
+            self.__name = vehicle_name
+
+            -- call original function
+            return au_setText(self, vehicle_name)
+        end
+    end
+else
+    minetest.log("warning", "[mapserver-bridge] no airutils!")
+end
+
+mapserver.bridge.add_airutils_planes = function(data)
+    data.airutils_planes = {}
+    for _, plane in pairs(planes) do
+        if plane then
+            -- do some extra work for passengers, which vary between planes
+            local passengers
+            if plane._passenger then
+                passengers = plane._passenger
+            elseif plane._passengers then
+                for _, p in ipairs(plane._passengers) do
+                    if p then
+                        if passengers then passengers = passengers .. ", " .. p
+                        else passengers = p end
+                    end
+                end
+            end
+
+            -- blimp uses color while others use _color
+            local color
+            if plane.color then color = plane.color
+            else color = plane._color end
+
+            table.insert(data.airutils_planes, {
+                entity = plane.name,
+                name = plane.__name,
+                id = plane.__id,
+                owner = plane.owner,
+                driver = plane.driver_name,
+                passenger = passengers,
+                color = color,
+                pos = plane.object:get_pos(),
+                yaw = plane.object:get_yaw()
+            })
+        end
+    end
+end

--- a/bridge/init.lua
+++ b/bridge/init.lua
@@ -10,6 +10,11 @@ local has_advtrains = minetest.get_modpath("advtrains")
 local has_locator = minetest.get_modpath("locator")
 local has_monitoring = minetest.get_modpath("monitoring")
 
+local has_airutils = minetest.get_modpath("airutils")
+if has_airutils then
+    dofile(MP .. "/bridge/airutils_planes.lua")
+end
+
 local metric_post_size
 local metric_processing_post_time
 local metric_post_time
@@ -48,6 +53,11 @@ function send_stats()
   if has_locator then
 	-- send locator beacons
 	mapserver.bridge.add_locators(data)
+  end
+
+  if has_airutils then
+	-- send airutils plane entities
+	mapserver.bridge.add_airutils_planes(data)
   end
 
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,3 @@
 name = mapserver
 description = Mod for the mapserver.
-optional_depends = default, dye, advtrains, monitoring, bones, mcl_core, mcl_sounds, mcl_dye, qos
+optional_depends = default, dye, advtrains, monitoring, bones, mcl_core, mcl_sounds, mcl_dye, qos, airutils


### PR DESCRIPTION
This adds support for the various planes implemented by @APercy which use his [airutils](https://github.com/APercy/airutils) library.

By targetting the AirUtils library, we get support for all plane mods which use it, relatively easily (though some special handling is already added here, for differences in colour and passenger handling).

This implementation sends the owner, pilot ("driver"), and passenger lists, along with colour. Yaw is sent so we can render the plane's correct orientation on the map.

Tested with:

- [Super Duck](https://content.minetest.net/packages/apercy/hidroplane/) ("hidroplane")
- [Super Cub](https://content.minetest.net/packages/apercy/supercub/)
- [PA28](https://content.minetest.net/packages/apercy/pa28/)
- [Trike](https://content.minetest.net/packages/apercy/trike/)
- [Ju52](https://content.minetest.net/packages/apercy/ju52/)
- [Steampunk Blimp](https://content.minetest.net/packages/apercy/steampunk_blimp/)

