### PR TITLE
Add player look direction

### DIFF
--- a/bridge/players.lua
+++ b/bridge/players.lua
@@ -25,6 +25,7 @@ mapserver.bridge.add_players = function(data)
       velocity = player:get_velocity(),
       moderator = is_moderator,
       rtt = rtt,
+      yaw = player:get_look_horizontal(),
       protocol_version = protocol_version
     }
 


### PR DESCRIPTION
Adds the player's camera/look direction to the payload sent to the map server.

See the companion PR at minetest-mapserver/mapserver#283